### PR TITLE
 Updates for Director-free process changes, fix #30 

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@ to the Recommendation track. That includes drafting the Deliverables section of 
 
 <p>These are offered as  guidelines, not a checklist of required items in every proposal.
   
-Meeting all the guidelines will not guarantee the <a href="https://www.w3.org/2023/Process-20230612/#def-w3c-decision">W3C decision</a> for <a href="https://www.w3.org/2023/Process-20230612/#cfp">approval of the charter</a>, or <a href="https://www.w3.org/2023/Process-20230612/#maturity-stages">advancement to FPWD</a>, nor will failing to meet some block approval. <em>The goal
+Meeting all the guidelines will not guarantee the <a href="https://www.w3.org/2023/Process-20230612/#def-w3c-decision">W3C decision</a> for <a href="https://www.w3.org/Consortium/Process/#cfp">approval of the charter</a>, or <a href="https://www.w3.org/Consortium/Process/#maturity-stages">advancement to FPWD</a>, nor will failing to meet some block approval. <em>The goal
 of this effort is to add more structure and predictability to Rec track decisions while allowing plenty of room for innovtion by 
 WGs and determination of W3C Decisions.</em></p>
 

--- a/index.html
+++ b/index.html
@@ -135,12 +135,12 @@ about how to interpret it.  They do not mandate any one mode of gathering that e
 ready for the W3C Recommendation Track. No single factor is decisive, and this document avoids <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a> "MUST" and "SHOULD" terminology, and should not be a taken
 as a checklist of necessary or sufficient criteria.  Nevertheless, some criteria are
 noted as "strongly recommended", and, if not met, an explanation of why they don't apply in a particular situation would 
-facilitate the Director's decision.  Different cases will involve different combinations of these factors. In determining whether to 
-approve moving work to the Recommendation track, the Director may consider
+facilitate the <a href="https://www.w3.org/2023/Process-20230612/#decision-types">W3C decision</a>.  Different cases will involve different combinations of these factors. In determining whether to 
+approve moving work to the Recommendation track, the Team may consider
 other factors not listed in this document as well.</p>
 
 <p>Assessing whether proposed work is likely to fulfull the W3C mission to <a href="http://www.w3.org/Consortium/mission">lead the web to its full potential</a>
-is the traditional criterion the Team and Director use to evaluate whether to start a working group or advance
+is the traditional criterion the Team and Advisory Committee use to evaluate whether to start a working group or advance
 a specification.  While this is "aspirational", it requires
 judgment that balances the future potential of the Web alongside the need for real developers to make the Web work in practice.
 This document seeks to make the factors that go into this judgment 

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@ to the Recommendation track. That includes drafting the Deliverables section of 
 
 <p>These are offered as  guidelines, not a checklist of required items in every proposal.
   
-Meeting all the guidelines will not guarantee the <a href="https://www.w3.org/2023/Process-20230612/#def-w3c-decision">W3C decision</a> for <a href="https://www.w3.org/Consortium/Process/#cfp">approval of the charter</a>, or <a href="https://www.w3.org/Consortium/Process/#maturity-stages">advancement to FPWD</a>, nor will failing to meet some block approval. <em>The goal
+Meeting all the guidelines will not guarantee the <a href="https://www.w3.org/Consortium/Process/#def-w3c-decision">W3C decision</a> for <a href="https://www.w3.org/Consortium/Process/#cfp">approval of the charter</a>, or <a href="https://www.w3.org/Consortium/Process/#maturity-stages">advancement to FPWD</a>, nor will failing to meet some block approval. <em>The goal
 of this effort is to add more structure and predictability to Rec track decisions while allowing plenty of room for innovtion by 
 WGs and determination of W3C Decisions.</em></p>
 

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
       <h2>
         <a name="status" id="status">Status</a>
       </h2>
+      <p>October 2023: Document updated to account for <a href="https://www.w3.org/2023/Process-20230612/#changes-2021">changes in Process 2023</a>, in particular the Director-free changes.</p>
       <p>August 2016: This document was developed by a task force of the <a href="https://www.w3.org/2002/ab/">W3C Advisory Board</a>, socialised to the W3C Advisory Committee and W3C Team.</p>
       <p>This <a href="https://github.com/w3c/standards-track/blob/master/index.html">document lives in Github</a>, where changes can be tracked and pull requests are welcome. 
         Feedback and comments are welcome. Please use <a href="https://github.com/w3c/standards-track/issues">Github issues</a>.</p>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
           <img src="https://www.w3.org/Icons/WWW/w3c_home_nb" alt="W3C" height="48" width="72">
         </a>
       </span>
-      <div class="breadcrumb"><a href="https://www.w3.org/Member/">Member</a> → <a href="https://www.w3.org/Guide/">The Art of Consensus</a> → 
+      <div class="breadcrumb"><a href="https://www.w3.org/participate/">Participate</a> → <a href="https://www.w3.org/Guide/">The Art of Consensus</a> → 
 <h1>W3C Recommendation Track Readiness Best Practices</h1></div>
       <p class="baseline">This <strong>Guidebook</strong> is the collected wisdom of the W3C Group Chairs and other collaborators.</p>
     </div>

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@ about how to interpret it.  They do not mandate any one mode of gathering that e
 ready for the W3C Recommendation Track. No single factor is decisive, and this document avoids <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a> "MUST" and "SHOULD" terminology, and should not be a taken
 as a checklist of necessary or sufficient criteria.  Nevertheless, some criteria are
 noted as "strongly recommended", and, if not met, an explanation of why they don't apply in a particular situation would 
-facilitate the <a href="https://www.w3.org/2023/Process-20230612/#decision-types">W3C decision</a>.  Different cases will involve different combinations of these factors. In determining whether to 
+facilitate the <a href="https://www.w3.org/Consortium/Process/#decision-types">W3C decision</a>.  Different cases will involve different combinations of these factors. In determining whether to 
 approve moving work to the Recommendation track, the Team may consider
 other factors not listed in this document as well.</p>
 

--- a/index.html
+++ b/index.html
@@ -72,9 +72,9 @@ and be used on the real Web. This document proposes to do that by offering a sho
 to the Recommendation track. That includes drafting the Deliverables section of a WG charter, but especially when publishing a FPWD. </p>
 
 <p>These are offered as  guidelines, not a checklist of required items in every proposal.
-Meeting all the guidelines will not guarantee Director approval of the charter or FPWD, nor will failing to meet some block approval. <em>The goal
+Meeting all the guidelines will not guarantee the <a href="https://www.w3.org/2023/Process-20230612/#def-w3c-decision">W3C decision</a> for <a href="https://www.w3.org/2023/Process-20230612/#cfp">approval of the charter</a>, or <a href="https://www.w3.org/2023/Process-20230612/#maturity-stages">advancement to FPWD</a>, nor will failing to meet some block approval. <em>The goal
 of this effort is to add more structure and predictability to Rec track decisions while allowing plenty of room for innovtion by 
-WGs and judgment by the Director.</em></p>
+WGs and determination of W3C Decisions.</em></p>
 
 <p>The target audience  for this document includes:</p>
 

--- a/index.html
+++ b/index.html
@@ -79,8 +79,8 @@ WGs and determination of W3C Decisions.</em></p>
 <p>The target audience  for this document includes:</p>
 
 <ul>
-<li>the Team and Director and Advisory Committee when evaluating proposals to create new Working Groups or rechartering existing Working Groups to put new work in scope (e.g. how specs reach maturation before FPWD), and in reviewing Proposed Recommendations;</li>
-<li>working group Chairs  determining whether to publish First Public Working Drafts of 
+<li>the Team and Advisory Committee, when evaluating proposals to create new Working Groups or rechartering existing Working Groups to put new work in scope (e.g. how specs reach maturation before FPWD), and in reviewing Proposed Recommendations;</li>
+<li>working group Chairs, when determining whether to publish First Public Working Drafts of 
 specs that are in a group's chartered scope, </li>
 </ul>
 


### PR DESCRIPTION
The 2023 Process introduces [changes, in particular a Director-free approach](https://www.w3.org/2023/Process-20230612/#changes-2021) and thus, this useful document (which has six mentions of Director decisions or Director involvement) has been updated to take these into account. 